### PR TITLE
Allow more fleshed out definitions

### DIFF
--- a/lib/lita/handlers/wtf.rb
+++ b/lib/lita/handlers/wtf.rb
@@ -2,7 +2,7 @@ module Lita
   module Handlers
     class Wtf < Handler
       route(
-        /^wtf(?:\s+is)?\s(?<term>\w+)(?:\?)?/,
+        /^wtf(?:\s+is)?\s(?<term>\S+)(?:\?)?/,
         :lookup,
         command: true,
         help: {

--- a/lib/lita/handlers/wtf.rb
+++ b/lib/lita/handlers/wtf.rb
@@ -2,7 +2,7 @@ module Lita
   module Handlers
     class Wtf < Handler
       route(
-        /^wtf(?:\s+is)?\s(?<term>\S+)(?:\?)?/,
+        /^wtf(?:\s+is)?\s(?<term>[^\s@#]+)(?:\?)?/,
         :lookup,
         command: true,
         help: {
@@ -11,7 +11,7 @@ module Lita
       )
 
       route(
-        /^define\s(?<term>\S+)\sis\s(?<definition>.+)$/,
+        /^define\s(?<term>[^\s@#]+)\sis\s(?<definition>[^#@]+)$/,
         :define,
         command: true,
         help: {

--- a/lib/lita/handlers/wtf.rb
+++ b/lib/lita/handlers/wtf.rb
@@ -11,7 +11,7 @@ module Lita
       )
 
       route(
-        /^define\s(?<term>\w+)\sis\s(?<definition>.+)$/,
+        /^define\s(?<term>\S+)\sis\s(?<definition>.+)$/,
         :define,
         command: true,
         help: {

--- a/lita-wtf.gemspec
+++ b/lita-wtf.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-wtf'
-  spec.version       = '1.0.0'
+  spec.version       = '1.0.1'
   spec.authors       = ['Eric Sigler']
   spec.email         = ['me@esigler.com']
   spec.description   = 'A user-controlled dictionary plugin for Lita'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,7 +6,7 @@ en:
           wtf:
             syntax: wtf is <term>?
             desc: Get the description of <term>
-          define:
+          desc:
             syntax: define <term> is <defintion>
             define: Set the description of <term> to <definition>
         wtf:

--- a/spec/lita/handlers/wtf_spec.rb
+++ b/spec/lita/handlers/wtf_spec.rb
@@ -15,9 +15,9 @@ describe Lita::Handlers::Wtf, lita_handler: true do
     end
 
     it 'allows definitions with lots of weird characters' do
-      send_command('define &&--88^%!@#$*() is garbage text')
-      send_command('wtf is &&--88^%!@#$*()')
-      expect(replies.last).to eq('&&--88^%!@#$*() is garbage text')
+      send_command('define &&--88^%!$*() is garbage text')
+      send_command('wtf is &&--88^%!$*()')
+      expect(replies.last).to eq('&&--88^%!$*() is garbage text')
     end
 
     it 'responds with the definition of a capitalized service' do

--- a/spec/lita/handlers/wtf_spec.rb
+++ b/spec/lita/handlers/wtf_spec.rb
@@ -14,6 +14,12 @@ describe Lita::Handlers::Wtf, lita_handler: true do
       expect(replies.last).to eq('web is Rails. Rails. Rails.')
     end
 
+    it 'allows definitions with lots of weird characters' do
+      send_command('define &&--88^%!@#$*() is garbage text')
+      send_command('wtf is &&--88^%!@#$*()')
+      expect(replies.last).to eq('&&--88^%!@#$*() is garbage text')
+    end
+
     it 'responds with the definition of a capitalized service' do
       send_command('define web is Rails. Rails. Rails.')
       send_command('wtf is WEB')


### PR DESCRIPTION
One downside is it becomes disabled by slak a bit. I think though to work otherwise we would end up needing to write a separate regex for any chat provider which seems out of scope.
