### PR TITLE
Add the ability to look up in secondary sources, in addition to the internal database.

### DIFF
--- a/lib/lita/handlers/wtf.rb
+++ b/lib/lita/handlers/wtf.rb
@@ -1,6 +1,16 @@
+require 'nokogiri'
+
 module Lita
   module Handlers
     class Wtf < Handler
+      config :see_also, required: false, type: Array, default: []
+      config :api_keys, required: false, type: Hash, default: {}
+
+      SOURCE_NAMES = {
+        'merriam' => 'Merriam-Webster Collegiate Dictionary',
+        'urbandictionary' => 'UrbanDictionary'
+      }
+
       route(
         /^wtf(?:\s+is)?\s(?<term>[^\s@#]+)(?:\?)?/,
         :lookup,
@@ -21,8 +31,18 @@ module Lita
 
       def lookup(response)
         term = response.match_data['term']
-        return response.reply(t('wtf.unknown', term: term)) unless known?(term)
-        response.reply(format_definition(term, definition(term)))
+        if known?(term)
+          response.reply(format_definition(term, definition(term)))
+        else
+          config.see_also.each do |source_name|
+            definition = self.send("lookup_#{source_name}", term)
+            if definition
+              return response.reply(t('wtf.seealso',
+                term: term, definition: definition, source: SOURCE_NAMES[source_name]))
+            end
+          end
+          response.reply(t('wtf.unknown', term: term))
+        end
       end
 
       def define(response)
@@ -49,6 +69,36 @@ module Lita
       def write(term, definition, owner)
         redis.hset(term.downcase, 'definition', definition)
         redis.hset(term.downcase, 'owner', owner)
+      end
+
+      def lookup_merriam(term)
+        api_key = config.api_keys['merriam']
+        response = http.get("http://www.dictionaryapi.com/api/v1/references/collegiate/xml/#{term}", key: api_key)
+        if response.status == 200
+          doc = Nokogiri::XML(response.body) do |config|
+            config.options = Nokogiri::XML::ParseOptions::STRICT | Nokogiri::XML::ParseOptions::NONET
+          end
+
+          entries = doc.css("//entry/@id")
+          unless entries.empty?
+            first_entry_key = entries[0].value
+            defs = doc.css("//entry[@id=\"#{first_entry_key}\"]/def/dt")
+            defs.inject('') { |str, definition| str << "\n - " << definition.text[1..-1] }
+          end
+        end
+      end
+
+      def lookup_urbandictionary(term)
+        response = http.get("http://api.urbandictionary.com/v0/define", term: term)
+        if response.status == 200
+          def_list = JSON.parse(response.body)['list']
+
+          if def_list && def_list.size > 0
+            def_text = def_list[0]['definition']
+            def_text = def_text[0].downcase + def_text[1..-1] # uncapitalize the first letter
+            def_text.gsub("\r\n\r\n", "\r\n") # remove empty lines
+          end
+        end
       end
     end
 

--- a/lita-wtf.gemspec
+++ b/lita-wtf.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.0'
+  spec.add_runtime_dependency 'nokogiri'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'coveralls'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -11,4 +11,5 @@ en:
             desc: Set the description of <term> to <definition>
         wtf:
           is: "%{term} is %{definition}"
+          seealso: "According to %{source}, %{term} is %{definition}.\nTo replace this with our own definition, type: define %{term} is <description>."
           unknown: "I don't know what %{term} is, type: define %{term} is <description> to set it."


### PR DESCRIPTION
Implement Urban Dictionary and Merriam-Webster lookup as examples.

Configuration:
    config.handlers.wtf.see_also = ['merriam', 'urbandictionary']
to set the lookup plugins used and their order of precedence
    config.handlers.wtf.api_keys = {'merriam' => 'teh-very-sikrit-API-passw0rd'}
to set the M-W developer key
