### PR TITLE
Add `what is` alternative to `wtf`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/tmp
 test/version_tmp
 tmp
 .env
+bin/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,5 @@ LineLength:
 AllCops:
   Exclude:
     - spec/**/*
+    - vendor/**/*
+    - bin/**/*

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require 'rubocop/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new(:rubocop)
 
-task default: %i[spec rubocop]
+task default: %i(spec rubocop)

--- a/lib/lita/handlers/wtf.rb
+++ b/lib/lita/handlers/wtf.rb
@@ -19,6 +19,15 @@ module Lita
       )
 
       route(
+        /^what(?:\s+is)?\s+(?<term>[^\s@#]+)(?:\?)?/,
+        :lookup,
+        command: true,
+        help: {
+          t('help.wtf.syntax') => t('help.wtf.desc')
+        }
+      )
+
+      route(
         /^define\s(?<term>[^\s@#]+)\sis\s(?<definition>[^#@]+)$/,
         :define,
         command: true,

--- a/lita-wtf.gemspec
+++ b/lita-wtf.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-wtf'
-  spec.version       = '1.1.1'
+  spec.version       = '1.2.0'
   spec.authors       = ['Eric Sigler', 'Rob Ottaway', 'Max T']
   spec.email         = ['me@esigler.com', 'rottaway@pagerduty.com', 'github@maxvt.com']
   spec.description   = 'A user-controlled dictionary plugin for Lita'

--- a/lita-wtf.gemspec
+++ b/lita-wtf.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '0.39.0'
   spec.add_development_dependency 'simplecov'
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,7 +4,7 @@ en:
       wtf:
         help:
           wtf:
-            syntax: wtf is <term>
+            syntax: wtf is <term>, what is <term>
             desc: Get the description of <term>
           define:
             syntax: define <term> is <defintion>

--- a/spec/lita/handlers/wtf_spec.rb
+++ b/spec/lita/handlers/wtf_spec.rb
@@ -2,10 +2,12 @@ require 'spec_helper'
 
 describe Lita::Handlers::Wtf, lita_handler: true do
   it { is_expected.to route_command('wtf is foo').to(:lookup) }
+  it { is_expected.to route_command('what is foo').to(:lookup) }
 
   it { is_expected.to route_command('wtf foo').to(:lookup) }
   it { is_expected.to route_command('wtf foo ').to(:lookup) }
   it { is_expected.to route_command('wtf  foo').to(:lookup) }
+  it { is_expected.to route_command('what foo').to(:lookup) }
 
   it { is_expected.to route_command('define foo is bar').to(:define) }
 


### PR DESCRIPTION
To be more inclusive of people's swearing preferences :)

```
$ bundle exec lita
Type "exit" or "quit" to end the session.
Lita > lita what is stompy
I don't know what stompy is, type: define stompy is <description> to set it.
Lita > lita define stompy is marguerite
stompy is marguerite
Lita > lita what is stompy
stompy is marguerite
Lita > lita what stompy
stompy is marguerite
```